### PR TITLE
Add support for ESP32-C6

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,10 @@
 [build]
-# Uncomment the relevant target for your chip here (ESP32, ESP32-S2, ESP32-S3 or ESP32-C3)
+# Uncomment the relevant target for your chip here (ESP32, ESP32-S2, ESP32-S3, ESP32-C3 or ESP32-C6)
 #target = "xtensa-esp32-espidf"
 #target = "xtensa-esp32s2-espidf"
 #target = "xtensa-esp32s3-espidf"
 target = "riscv32imc-esp-espidf"
-#target = "riscv32imac-esp-espidf"
+#target = "riscv32imac-esp-espidf" # for ESP32-C6, set MCU environment variable at the end of the file as well
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
@@ -35,5 +35,5 @@ rustflags = ["--cfg", "mio_unsupported_force_poll_poll", "--cfg", "espidf_time64
 build-std = ["std", "panic_abort"]
 
 [env]
-ESP_IDF_VERSION = "release/v5.0"
-CROSS_COMPILE = { value = ".embuild/espressif/tools/riscv32-esp-elf/esp-12.2.0_20230208/riscv32-esp-elf/bin/riscv32-esp-elf", relative = true }
+#MCU = "esp32c6" # esp-idf build for `riscv32imac-esp-espidf` target defaults to ESP32-H2 MCU
+ESP_IDF_VERSION = "release/v5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ socket2 = { git = "https://github.com/rust-lang/socket2", branch = "master" }
 
 [dependencies]
 esp-idf-sys = { version = "0.33.1", features = ["binstart"] }
-esp-idf-svc = { version = "0.46.0", features = ["experimental"] }
-esp-idf-hal = "0.41.2"
-embedded-svc = { version = "0.25.3", features = ["experimental"] }
+esp-idf-svc = { version = "0.47.3", features = ["experimental"] }
+esp-idf-hal = "0.42.5"
+embedded-svc = { version = "0.26.4", features = ["experimental"] }
 embedded-hal = "0.2.7"
 log = "0.4.17"
 anyhow = "1"


### PR DESCRIPTION
This adds support for ESP32-C6 by bumping the ESP-IDF version to v5.1 and providing the required MCU environment variable.
Also, this fixes the compilation on Rust 1.74 by bumping the ESP-IDF Rust dependencies (fixes #3).

Unfortunately, I can only test this on ESP32-C3 and ESP32-C6 hardware, but at least building for the Xtensa targets still works on my machine.